### PR TITLE
Key mapping does not work on windows

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,5 @@
 [
     {
-        "keys": ["super+shift+r"], "command": "cypher"
+        "keys": ["ctrl+shift+r"], "command": "cypher"
     }
 ]


### PR DESCRIPTION
I tried using Ctrl and Alt, but neither reacted, and I couldn't find any doco explaining what `super` is. Changing it to `ctrl` got it working for me on Windows.
