### PR TITLE
Adding UTF-8 encoding to query results.

### DIFF
--- a/Cypher.py
+++ b/Cypher.py
@@ -17,7 +17,10 @@ def item_to_str(item):
         else:
             return "(%s %s)" % (id_, data)
     else:
-        return str(item.encode('utf-8'))
+        try:
+            return str(item)
+        except ValueError:
+            return str(item.encode('utf-8'))
 
 
 def print_table(headers, items):


### PR DESCRIPTION
If the Cypher results include unicode, the user will encounter an error within Sublime's terminal like this:

UnicodeEncodeError: 'ascii' codec can't encode character u'\u201c' in position 36: ordinal not in range(128)

This conversion fixes that.
